### PR TITLE
Build and docs cleanup

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -185,6 +185,22 @@ MIT License
 Pull requests and feature ideas are welcome!  
 Open an issue to start the discussion.
 
+### Contributor Requirements
+
+- Use **JDK 21** (the project can auto-download toolchains via Gradle, but local JDK 21 is recommended)
+- Use the latest stable **Android Studio** with Kotlin Multiplatform support enabled
+- For iOS changes, use a recent **Xcode** version and verify iOS build compiles
+- Keep formatting and code style aligned with project defaults (`kotlin.code.style=official`)
+- Add or update tests when behavior changes
+- Update docs/examples when public API behavior changes
+
+### Before Opening a PR
+
+- Run a clean build and relevant tests locally
+- Keep PRs focused (single feature/fix per PR)
+- Include a clear description of what changed and why
+- For UI/UX changes, include screenshots or a short screen recording
+
 ---
 
 ## 👤 Maintainer

--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.rufenkhokhar/KMP-Player)](https://central.sonatype.com/artifact/io.github.rufenkhokhar/KMP-Player)
 ![Kotlin](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
-![Platform](https://img.shields.io/badge/Platforms-Android%20|%20iOS-blue)
+![Platform](https://img.shields.io/badge/Platforms-Android%20%7C%20iOS-blue)
 ![Compose](https://img.shields.io/badge/Jetpack-Compose-4285F4?logo=jetpackcompose&logoColor=white)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 ![Issues](https://img.shields.io/github/issues/rufenkhokhar/KMP-Player)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@ plugins {
     alias(libs.plugins.multiplatform).apply(false)
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.android.application).apply(false)
+    alias(libs.plugins.maven.publish).apply(false)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.daemon=true
 org.gradle.parallel=true
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true
 
 #Kotlin
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,12 @@
 [versions]
 
 kotlin = "2.2.10"
-agp = "8.12.0"
+agp = "8.13.0"
 compose = "1.8.2"
 androidx-activityCompose = "1.10.1"
 kotlinx-coroutines = "1.10.2"
 media3 = "1.8.0"
+maven-publish = "0.34.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -21,3 +22,4 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/kmpplayer/build.gradle.kts
+++ b/kmpplayer/build.gradle.kts
@@ -1,10 +1,9 @@
-
 plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.compose)
     alias(libs.plugins.compose.compiler)
-    id("com.vanniktech.maven.publish") version "+"
+    alias(libs.plugins.maven.publish)
 }
 
 group = "io.github.rufenkhokhar"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-rootProject.name = "KMP-Player"
-
 pluginManagement {
     repositories {
         google {
@@ -14,6 +12,12 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+rootProject.name = "KMP-Player"
 
 dependencyResolutionManagement {
     repositories {
@@ -30,4 +34,3 @@ dependencyResolutionManagement {
 }
 include(":kmpplayer")
 include(":sample:composeApp")
-


### PR DESCRIPTION
## Overview
This PR includes small build/docs maintenance updates to improve project setup consistency.

## Changes
- Pinned AGP and publishing plugin versions (removed dynamic `+` usage)
- Added root plugin declaration for `com.vanniktech.maven.publish` (`apply false`)
- Enabled Gradle Java toolchain auto-detect/auto-download
- Added and pinned Foojay toolchain resolver in `settings.gradle.kts`
- Expanded `README.MD` contributing requirements/checklist (fixes a URL that broke jetbrains markdown plugin)

## Why
- Prevent Gradle sync/version drift issues
- Make onboarding easier for contributors (especially around JDK 21/toolchains)
- Clarify contribution expectations (used some standard defaults, feel free to suggest changes or removal)

## Validation
- `./gradlew help --no-daemon` passes locally